### PR TITLE
Fix eager load

### DIFF
--- a/lib/route_mechanic/testing/methods.rb
+++ b/lib/route_mechanic/testing/methods.rb
@@ -55,9 +55,8 @@ module RouteMechanic
       # If complicated controllers path is used, use Rails.application.eager_load! instead.
       def eager_load_controllers
         load_path = "#{Rails.root.join('app/controllers')}"
-        relname_range = (load_path.to_s.length + 1)...-3
         Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
-          require_dependency file[relname_range]
+          require_dependency file
         end
       end
 


### PR DESCRIPTION
Just file name like 'require "users_controller"' fails.
Besides, 'require "app/controllers/users_controller"' is also ambiguous.
So make it loads with full path

```
E

Error:
RoutingTest#test_that_application_has_correct_routes:
LoadError: No such file to load -- application_controller.rb
    test/routing/routing_test.rb:6:in `test_that_application_has_correct_routes'

rails test test/routing/routing_test.rb:4

Finished in 480.253456s, 0.0021 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```