### PR TITLE
Cover case when routes is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Just add a test file which has only one test case using `have_valid_routes` matc
 ```ruby
 RSpec.describe 'Rails.application', type: :routing do
   it "fails if application does not have valid routes" do
-   expect(Rails.application.routes).to have_valid_routes
+   expect(Rails.application).to have_valid_routes
   end
 end
 ```

--- a/lib/route_mechanic/rspec/matchers.rb
+++ b/lib/route_mechanic/rspec/matchers.rb
@@ -8,7 +8,7 @@ module RouteMechanic
         include ::RSpec::Matchers::Composable
         include RouteMechanic::Testing::Methods
 
-        # @param [ActionDispatch::Routing::RouteSet] expected
+        # @param [Rails::Application] expected
         def initialize(expected)
           @expected = expected
         end
@@ -42,8 +42,8 @@ module RouteMechanic
         end
       end
 
-      def have_valid_routes(routes=Rails.application.routes)
-        HaveValidRoutes.new(routes)
+      def have_valid_routes(application=Rails.application)
+        HaveValidRoutes.new(application)
       end
     end
   end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RouteMechanic::RSpec::Matchers, type: :routing do
 
   it "fails if application does not have valid routes" do
     expect {
-      expect(Rails.application.routes).to have_valid_routes
+      expect(Rails.application).to have_valid_routes
     }.to raise_error(<<~MSG)
         [Route Mechanic]
           No route matches to the controllers and action methods below


### PR DESCRIPTION
## Problem

It's possible that `Rails.application.routes` is not loaded in Rails tests. In that case, many missing routes would be reported by this gem.

## Solution

If no route is loaded, route_mechanic loads `config/routes.rb` automatically.