### PR TITLE
Fix indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Just add a test file which has only one test case using `have_valid_routes` matc
 ```ruby
 RSpec.describe 'Rails.application', type: :routing do
   it "fails if application does not have valid routes" do
-   expect(Rails.application).to have_valid_routes
+    expect(Rails.application).to have_valid_routes
   end
 end
 ```


### PR DESCRIPTION
Basically we use 2 spaces indentation in Ruby, but it has one space indentation in the example. 
This pull request will fix it.