### PR TITLE
Fix an error on mountable engine with a default param

### DIFF
--- a/fixtures/fake_app/lib/engine.rb
+++ b/fixtures/fake_app/lib/engine.rb
@@ -1,0 +1,5 @@
+module FakeEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace FakeEngine
+  end
+end

--- a/fixtures/fake_app/rails_app.rb
+++ b/fixtures/fake_app/rails_app.rb
@@ -1,6 +1,8 @@
 require 'rails/application'
 require "action_controller/railtie"
 
+require_relative './lib/engine'
+
 FakeApp = Class.new(Rails::Application)
 FakeApp.config.eager_load = false
 FakeApp.config.hosts << 'www.example.com' if FakeApp.config.respond_to?(:hosts)
@@ -10,5 +12,6 @@ FakeApp.initialize!
 FakeApp.routes.draw do
   resources :users do
     get 'friends', to: :friends
+    mount FakeEngine::Engine, at: "/fake_engine", fake_default_param: 'FAKE'
   end
 end

--- a/lib/route_mechanic/testing/methods.rb
+++ b/lib/route_mechanic/testing/methods.rb
@@ -78,7 +78,7 @@ module RouteMechanic
           # Skip internals, endpoints that Rails adds by default
           # Also Engines should be skipped since Engine's tests should be done in Engine
           wrapper = RouteWrapper.new(journey_route)
-          wrapper.internal? || wrapper.required_defaults.empty? || wrapper.path.start_with?('/rails/')
+          wrapper.internal? || !wrapper.defaults[:controller] || !wrapper.defaults[:action] || wrapper.path.start_with?('/rails/')
         end
       end
     end


### PR DESCRIPTION
# Problem

I tried to apply this gem to our application, but I got an error. The cause is a mountable engine with a default parameter.
Actually, it is [graphiql-rails](https://github.com/rmosolgo/graphiql-rails) in my case.
Because graphiql-rails needs `graphql_path` as a default parameter in routes.rb, like `mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/your/endpoint"`.

We can reproduce the problem with the added test by this pull request.

```
$ bundle exec rake
# Running:

...F

Failure:
RouteMechanicTestingMethodsTest#test_that_fake_app_has_missing_routes [/path/to/route_mechanic/test/testing/methods_test.rb:45]:
[Minitest::Assertion] exception expected, not
Class: <NoMethodError>
Message: <"undefined method `to_sym' for nil:NilClass">
---Backtrace---
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:44:in `block (3 levels) in collect_controller_routes_errors'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:43:in `each'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:43:in `detect'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:43:in `block (2 levels) in collect_controller_routes_errors'
/path/to/2.7.1/lib/ruby/2.7.0/set.rb:328:in `each_key'
/path/to/2.7.1/lib/ruby/2.7.0/set.rb:328:in `each'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:42:in `block in collect_controller_routes_errors'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:40:in `each'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:40:in `collect_controller_routes_errors'
/path/to/route_mechanic/lib/route_mechanic/testing/error_aggregator.rb:20:in `aggregate'
/path/to/route_mechanic/lib/route_mechanic/testing/methods.rb:22:in `assert_all_routes'
/path/to/route_mechanic/test/testing/methods_test.rb:46:in `block in test_that_fake_app_has_missing_routes'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/assertions.rb:402:in `assert_raises'
/path/to/route_mechanic/test/testing/methods_test.rb:45:in `test_that_fake_app_has_missing_routes'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/test.rb:98:in `block (3 levels) in run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/test.rb:195:in `capture_exceptions'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/test.rb:95:in `block (2 levels) in run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:272:in `time_it'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/test.rb:94:in `block in run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:367:in `on_signal'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/test.rb:211:in `with_info_handler'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest/test.rb:93:in `run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:1029:in `run_one_method'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:341:in `run_one_method'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:328:in `block (2 levels) in run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:327:in `each'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:327:in `block in run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:367:in `on_signal'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:354:in `with_info_handler'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:326:in `run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:164:in `block in __run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:164:in `map'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:164:in `__run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:141:in `run'
/path/to/2.7.1/lib/ruby/gems/2.7.0/gems/minitest-5.14.2/lib/minitest.rb:68:in `block in autorun'
---------------


rails test /path/to/route_mechanic/test/testing/methods_test.rb:44
```


This gem skips tests for Engines by design. https://github.com/ohbarye/route_mechanic/blob/1fbddf35c135880c69b7e5b25231284631c1a9db/lib/route_mechanic/testing/methods.rb#L79
But accidentally it doesn't skip the test for an engine if the engine has a default parameter.
Because `Route#required_defaults` is not empty if it has a param that defined in routes.rb, such as `graphql_path`.


# Solution



Check controller and actions existence in `Route#defaults` instead of `wrapper.required_defaults.empty?`.

I think it is appropriate because this gem depends on their existence.
https://github.com/ohbarye/route_mechanic/blob/1fbddf35c135880c69b7e5b25231284631c1a9db/lib/route_mechanic/testing/error_aggregator.rb#L44

