### PR TITLE
Use loose assertion to pass constraints

### DIFF
--- a/fixtures/fake_app/rails_app.rb
+++ b/fixtures/fake_app/rails_app.rb
@@ -10,6 +10,10 @@ FakeApp.config.root = File.dirname(__FILE__)
 FakeApp.initialize!
 
 FakeApp.routes.draw do
+  constraints subdomain: /\A[0-9a-z-]+\z/ do
+    get '/constraints_test' => 'users#index'
+  end
+
   resources :users do
     get 'friends', to: :friends
     mount FakeEngine::Engine, at: "/fake_engine", fake_default_param: 'FAKE'

--- a/lib/route_mechanic/testing/methods.rb
+++ b/lib/route_mechanic/testing/methods.rb
@@ -53,7 +53,12 @@ module RouteMechanic
           base_option.merge({ only_path: true }).merge(required_parts))
         expected_options = base_option.merge(required_parts)
 
-        assert_routing({ path: url, method: wrapper.verb }, expected_options)
+        assert_generates(url, expected_options)
+        # Q. Why not using `assert_routing` or `assert_recognize`?
+        # A. They strictly checks `constraints` in routes.rb and
+        #    this gem can't generate a request that meets whole constraints just in time.
+        # https://github.com/ohbarye/route_mechanic/issues/7#issuecomment-695957142
+        # https://guides.rubyonrails.org/routing.html#specifying-constraints
       end
 
       # @return [Array<Controller>]

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe RouteMechanic::RSpec::Matchers, type: :routing do
           No route matches to the controllers and action methods below
             UsersController#unknown
           No controller and action matches to the routes below
+            GET    /constraints_test(.:format)       users#index
             GET    /users/:user_id/friends(.:format) users#friends
             GET    /users(.:format)                  users#index
             GET    /users/new(.:format)              users#new

--- a/spec/testing/methods_spec.rb
+++ b/spec/testing/methods_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RouteMechanic::Testing::Methods do
           No route matches to the controllers and action methods below
             UsersController#unknown
           No controller and action matches to the routes below
+            GET    /constraints_test(.:format)       users#index
             GET    /users/:user_id/friends(.:format) users#friends
             GET    /users(.:format)                  users#index
             GET    /users/new(.:format)              users#new

--- a/test/testing/methods_test.rb
+++ b/test/testing/methods_test.rb
@@ -51,6 +51,7 @@ class RouteMechanicTestingMethodsTest < Minitest::Test
         No route matches to the controllers and action methods below
           UsersController#unknown
         No controller and action matches to the routes below
+          GET    /constraints_test(.:format)       users#index
           GET    /users/:user_id/friends(.:format) users#friends
           GET    /users(.:format)                  users#index
           GET    /users/new(.:format)              users#new


### PR DESCRIPTION
## Issue

https://github.com/ohbarye/route_mechanic/issues/7

## Problem

As written in https://github.com/ohbarye/route_mechanic/issues/7#issuecomment-695957142, `assert_routing` and `assert_recoginizes` checks not only partial path (e.g. `/foo/:id/bar`) but also other information in full path.

## Solution

Use `assert_generates` instead of `assert_routing`.

📝 The main routing checks are done by https://github.com/ohbarye/route_mechanic/blob/master/lib/route_mechanic/testing/error_aggregator.rb. Those assertions provided by Rails are just _insurance_ that can detect patterns which `route_mechanic` cannot expect. 