### PR TITLE
Drop Ruby 2.3.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - ruby:2.3
           - ruby:2.4
           - ruby:2.5
           - ruby:2.6

--- a/route_mechanic.gemspec
+++ b/route_mechanic.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{No need to maintain Rails' routing tests manually. RouteMechanic automatically detects broken routes and missing action methods in controller once you've finished installation.}
   spec.homepage      = "https://github.com/ohbarye/route_mechanic"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ohbarye/route_mechanic"


### PR DESCRIPTION
After adding `regexp-examles`, it needs to drop ruby 2.3.0 support.