### PR TITLE
Do not report missing controller/action for aliased routes

### DIFF
--- a/fixtures/fake_app/rails_app.rb
+++ b/fixtures/fake_app/rails_app.rb
@@ -24,5 +24,6 @@ FakeApp.routes.draw do
   resources :users do
     get 'friends', to: :friends
     mount FakeEngine::Engine, at: "/fake_engine", fake_default_param: 'FAKE'
+    post 'create_as_another_name', to: 'users#create'
   end
 end

--- a/lib/route_mechanic/testing/error_aggregator.rb
+++ b/lib/route_mechanic/testing/error_aggregator.rb
@@ -40,15 +40,15 @@ module RouteMechanic
         @controllers.each do |controller|
           controller_path = controller.controller_path
           controller.action_methods.each do |action_method|
-            journey_route = @routes.detect do |route|
+            journey_routes = @routes.select do |route|
               route.defaults[:controller].to_sym == controller_path.to_sym && route.defaults[:action].to_sym == action_method.to_sym
             end
 
-            if journey_route
-              wrapper = RouteWrapper.new journey_route
-              @controller_routes << wrapper
-            else
+            if journey_routes.empty?
               @controller_routes_errors << { controller: controller, action: action_method }
+            else
+              wrappers = journey_routes.map { |r| RouteWrapper.new(r) }
+              @controller_routes.concat(wrappers)
             end
           end
         end


### PR DESCRIPTION
# Problem


This gem reports missing controller/action for aliased routes.
For example, it reports the following error with `post 'create_as_another_name', to: 'users#create'`. it is an alias of `POST /users`.

```
$ bundle exec rake

# Running:

..F

Failure:
RouteMechanicTestingMethodsTest#test_that_fake_app_has_missing_routes [/home/pocke/ghq/github.com/ohbarye/route_mechanic/test/testing/methods_test.rb:67]:
--- expected
+++ actual
@@ -8,6 +8,7 @@
     GET    /organizations/:id(.:format)      organizations#show {:id=>/[A-Z]\\d{5}/}
     GET    /users/:user_id/friends(.:format) users#friends
     GET    /users(.:format)                  users#index
+    POST   /users(.:format)                  users#create
     GET    /users/new(.:format)              users#new
     GET    /users/:id/edit(.:format)         users#edit
     GET    /users/:id(.:format)              users#show
```

But `users#create` action actually exists, so this error is a false positive.


# Cause

`collect_controller_routes_errors` only correct the first matched routes. 
https://github.com/ohbarye/route_mechanic/blob/cfcec96dd1544ea40dd7a6b41da201f0e64a4ebf/lib/route_mechanic/testing/error_aggregator.rb#L43

And `collect_config_routes_errors` uses the collected routes to check existence of the action.

So if an action matches several routes, it ignores routes except the first one. So `collect_config_routes_errors` can't find matched controller.


# Solution

Collect all routes in `collect_controller_routes_errors`.