### PR TITLE
support ActionController::API, exit strategy for when automatic controller loading doesn't work

### DIFF
--- a/fixtures/fake_app/app/controllers/api_controller.rb
+++ b/fixtures/fake_app/app/controllers/api_controller.rb
@@ -1,0 +1,4 @@
+class ApiController < ActionController::API
+  def computer_business
+  end
+end

--- a/fixtures/fake_app/rails_app.rb
+++ b/fixtures/fake_app/rails_app.rb
@@ -21,6 +21,8 @@ FakeApp.routes.draw do
 
   get 'organizations/:id', to: 'organizations#show', id: /[A-Z]\d{5}/
 
+  get 'computer_business', to: 'api#computer_business'
+
   resources :users do
     get 'friends', to: :friends
     mount FakeEngine::Engine, at: "/fake_engine", fake_default_param: 'FAKE'

--- a/lib/route_mechanic/rspec/matchers.rb
+++ b/lib/route_mechanic/rspec/matchers.rb
@@ -5,16 +5,16 @@ require 'route_mechanic/rspec/matchers/have_no_unused_routes'
 module RouteMechanic
   module RSpec
     module Matchers
-      def have_valid_routes(application=Rails.application)
-        HaveValidRoutes.new(application)
+      def have_valid_routes(application=Rails.application, extra_controllers: [], ignore_controllers: [])
+        HaveValidRoutes.new(application, extra_controllers: extra_controllers, ignore_controllers: ignore_controllers)
       end
 
-      def have_no_unused_actions(application=Rails.application)
-        HaveNoUnusedActions.new(application)
+      def have_no_unused_actions(application=Rails.application, extra_controllers: [], ignore_controllers: [])
+        HaveNoUnusedActions.new(application, extra_controllers: extra_controllers, ignore_controllers: ignore_controllers)
       end
 
-      def have_no_unused_routes(application=Rails.application)
-        HaveNoUnusedRoutes.new(application)
+      def have_no_unused_routes(application=Rails.application, extra_controllers: [], ignore_controllers: [])
+        HaveNoUnusedRoutes.new(application, extra_controllers: extra_controllers, ignore_controllers: ignore_controllers)
       end
     end
   end

--- a/lib/route_mechanic/rspec/matchers/base_matcher.rb
+++ b/lib/route_mechanic/rspec/matchers/base_matcher.rb
@@ -9,8 +9,10 @@ module RouteMechanic
         include RouteMechanic::Testing::Methods
 
         # @param [Rails::Application] expected
-        def initialize(expected)
+        def initialize(expected, extra_controllers: [], ignore_controllers: [])
           @expected = expected
+          @extra_controllers = extra_controllers
+          @ignore_controllers = ignore_controllers
         end
 
         def matches?(_actual)

--- a/lib/route_mechanic/rspec/matchers/have_no_unused_actions.rb
+++ b/lib/route_mechanic/rspec/matchers/have_no_unused_actions.rb
@@ -8,7 +8,7 @@ module RouteMechanic
           # assert_recognizes does not consider ActionController::RoutingError an
           # assertion failure, so we have to capture that and Assertion here.
           match_unless_raises Minitest::Assertion, ActiveSupport::TestCase::Assertion, ActionController::RoutingError do
-            assert_no_unused_actions(@expected)
+            assert_no_unused_actions(@expected, extra_controllers: @extra_controllers, ignore_controllers: @ignore_controllers)
           end
         end
 

--- a/lib/route_mechanic/rspec/matchers/have_no_unused_routes.rb
+++ b/lib/route_mechanic/rspec/matchers/have_no_unused_routes.rb
@@ -8,7 +8,7 @@ module RouteMechanic
           # assert_recognizes does not consider ActionController::RoutingError an
           # assertion failure, so we have to capture that and Assertion here.
           match_unless_raises Minitest::Assertion, ActiveSupport::TestCase::Assertion, ActionController::RoutingError do
-            assert_no_unused_routes(@expected)
+            assert_no_unused_routes(@expected, extra_controllers: @extra_controllers, ignore_controllers: @ignore_controllers)
           end
         end
 

--- a/lib/route_mechanic/rspec/matchers/have_valid_routes.rb
+++ b/lib/route_mechanic/rspec/matchers/have_valid_routes.rb
@@ -8,7 +8,7 @@ module RouteMechanic
           # assert_recognizes does not consider ActionController::RoutingError an
           # assertion failure, so we have to capture that and Assertion here.
           match_unless_raises Minitest::Assertion, ActiveSupport::TestCase::Assertion, ActionController::RoutingError do
-            assert_all_routes(@expected)
+            assert_all_routes(@expected, extra_controllers: @extra_controllers, ignore_controllers: @ignore_controllers)
           end
         end
 

--- a/lib/route_mechanic/testing/methods.rb
+++ b/lib/route_mechanic/testing/methods.rb
@@ -90,8 +90,9 @@ module RouteMechanic
 
       # @return [Array<Controller>]
       def controllers
-        eager_load_controllers
-        ApplicationController.descendants
+        eager_load_controllers.map { |controller|
+          controller.gsub(%r{.+app/controllers/}, '')[0..-4].classify.constantize
+        }
       end
 
       # In RAILS_ENV=test, eager load is false and `ApplicationController.descendants` might be empty.
@@ -99,7 +100,7 @@ module RouteMechanic
       # If complicated controllers path is used, use Rails.application.eager_load! instead.
       def eager_load_controllers
         load_path = "#{Rails.root.join('app/controllers')}"
-        Dir.glob("#{load_path}/**/*.rb").sort.each do |file|
+        Dir.glob("#{load_path}/**/*_controller.rb").sort.each do |file|
           require_dependency file
         end
       end

--- a/lib/route_mechanic/testing/methods.rb
+++ b/lib/route_mechanic/testing/methods.rb
@@ -13,20 +13,20 @@ module RouteMechanic
 
       # @param [Rails::Application] application
       # @raise [Minitest::Assertion]
-      def assert_all_routes(application=Rails.application)
-        assert_targets(application, unused_actions: true, unused_routes: true)
+      def assert_all_routes(application=Rails.application, extra_controllers: [], ignore_controllers: [])
+        assert_targets(application, unused_actions: true, unused_routes: true, extra_controllers: extra_controllers, ignore_controllers: ignore_controllers)
       end
 
       # @param [Rails::Application] application
       # @raise [Minitest::Assertion]
-      def assert_no_unused_actions(application=Rails.application)
-        assert_targets(application, unused_actions: true, unused_routes: false)
+      def assert_no_unused_actions(application=Rails.application, extra_controllers: [], ignore_controllers: [])
+        assert_targets(application, unused_actions: true, unused_routes: false, extra_controllers: extra_controllers, ignore_controllers: ignore_controllers)
       end
 
       # @param [Rails::Application] application
       # @raise [Minitest::Assertion]
-      def assert_no_unused_routes(application=Rails.application)
-        assert_targets(application, unused_actions: false, unused_routes: true)
+      def assert_no_unused_routes(application=Rails.application, extra_controllers: [], ignore_controllers: [])
+        assert_targets(application, unused_actions: false, unused_routes: true, extra_controllers: extra_controllers, ignore_controllers: ignore_controllers)
       end
 
       private
@@ -35,14 +35,14 @@ module RouteMechanic
       # @param [Boolean] unused_actions
       # @param [Boolean] unused_routes
       # @raise [Minitest::Assertion]
-      def assert_targets(application, unused_actions:, unused_routes:)
+      def assert_targets(application, unused_actions:, unused_routes:, extra_controllers: [], ignore_controllers: [])
         @application = application
 
         # Instead of including ActionController::TestCase::Behavior, set up
         # https://github.com/rails/rails/blob/5b6aa8c20a3abfd6274c83f196abf73cacb3400b/actionpack/lib/action_controller/test_case.rb#L519-L520
         @controller = nil unless defined? @controller
 
-        aggregator = ErrorAggregator.new(target_routes, controllers).aggregate(
+        aggregator = ErrorAggregator.new(target_routes, controllers + extra_controllers - ignore_controllers).aggregate(
           unused_actions: unused_actions, unused_routes: unused_routes)
         aggregator.all_routes.each { |wrapper| assert_routes(wrapper) }
 

--- a/test/testing/methods/assert_all_routes_test.rb
+++ b/test/testing/methods/assert_all_routes_test.rb
@@ -10,6 +10,7 @@ class AssertAllRoutesTest < Minitest::Test
         resources :users, only: %i[create update] do
           get :unknown
         end
+        get 'computer_business', to: 'api#computer_business'
       end
       assert_all_routes
     end
@@ -29,6 +30,7 @@ class AssertAllRoutesTest < Minitest::Test
       [Route Mechanic]
         No route matches to the controllers and action methods below
           UsersController#unknown
+          ApiController#computer_business
         No controller and action matches to the routes below
           GET    /users(.:format)          users#index
           GET    /users/new(.:format)      users#new

--- a/test/testing/methods/assert_all_routes_test.rb
+++ b/test/testing/methods/assert_all_routes_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 require 'fake_app/rails_app'
 
 class AssertAllRoutesTest < Minitest::Test
@@ -29,8 +29,8 @@ class AssertAllRoutesTest < Minitest::Test
     expected_message = <<~MSG
       [Route Mechanic]
         No route matches to the controllers and action methods below
-          UsersController#unknown
           ApiController#computer_business
+          UsersController#unknown
         No controller and action matches to the routes below
           GET    /users(.:format)          users#index
           GET    /users/new(.:format)      users#new

--- a/test/testing/methods/assert_no_unused_actions_test.rb
+++ b/test/testing/methods/assert_no_unused_actions_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 require 'fake_app/rails_app'
 
 class AssertNoUnusedActionsTest < Minitest::Test
@@ -30,8 +30,8 @@ class AssertNoUnusedActionsTest < Minitest::Test
     expected_message = <<~MSG
       [Route Mechanic]
         No route matches to the controllers and action methods below
-          UsersController#unknown
           ApiController#computer_business
+          UsersController#unknown
     MSG
 
     assert_equal expected_message, e.message

--- a/test/testing/methods/assert_no_unused_actions_test.rb
+++ b/test/testing/methods/assert_no_unused_actions_test.rb
@@ -10,6 +10,8 @@ class AssertNoUnusedActionsTest < Minitest::Test
         resources :users, only: %i[create update] do
           get :unknown
         end
+
+        get 'computer_business', to: 'api#computer_business'
       end
       assert_no_unused_actions
     end
@@ -29,6 +31,7 @@ class AssertNoUnusedActionsTest < Minitest::Test
       [Route Mechanic]
         No route matches to the controllers and action methods below
           UsersController#unknown
+          ApiController#computer_business
     MSG
 
     assert_equal expected_message, e.message


### PR DESCRIPTION
In my application, some of our controllers subclass `ActionController::API`.

I tried subclassing from `ActionController::Metal` but then lots of anonymous controllers were causing false negatives.

I also extended the API to support explicit addition & removal of controllers -- often helpful for when pulling in controllers from other gems