### PR TITLE
assert_routes performance improvement - use `random_example` instead of `examples.last`

### DIFF
--- a/lib/route_mechanic/testing/methods.rb
+++ b/lib/route_mechanic/testing/methods.rb
@@ -68,7 +68,7 @@ module RouteMechanic
       def assert_routes(wrapper)
         required_parts = wrapper.required_parts.reduce({}) do |memo, required_part|
           dummy = if wrapper.requirements[required_part].is_a?(Regexp)
-                    wrapper.requirements[required_part].examples.last
+                    wrapper.requirements[required_part].random_example
                   else
                     '1'
                   end


### PR DESCRIPTION
The revised approach is more performant, because it doesn't need to build a potentially-large array of examples before returning a single one.